### PR TITLE
.net10 upgrade + SPAXX Fix + Transfer Amount fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The current CLI is focused on Fidelity brokerage CSV files and emits OFX 2.1.1 s
 
 ## Requirements
 
-- .NET 8 SDK
+- .NET 10 SDK
 
 ## Build
 

--- a/src/Csv2Ofx.Gui/Csv2Ofx.Gui.csproj
+++ b/src/Csv2Ofx.Gui/Csv2Ofx.Gui.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Csv2Ofx.Gui</AssemblyName>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifiers>linux-x64;osx-x64;osx-arm64;win-x64</RuntimeIdentifiers>
     <UseAppHost>true</UseAppHost>
     <Nullable>enable</Nullable>

--- a/src/CsvToOfx.Cli/CsvToOfx.Cli.csproj
+++ b/src/CsvToOfx.Cli/CsvToOfx.Cli.csproj
@@ -20,7 +20,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14</LangVersion>
   </PropertyGroup>
 

--- a/src/CsvToOfx.Core/CsvToOfx.Core.csproj
+++ b/src/CsvToOfx.Core/CsvToOfx.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14</LangVersion>
   </PropertyGroup>
 

--- a/src/CsvToOfx.Core/Services/AmountParser.cs
+++ b/src/CsvToOfx.Core/Services/AmountParser.cs
@@ -1,10 +1,16 @@
 namespace CsvToOfx.Core.Services;
 public sealed class AmountParser
 {
-    public decimal? ParseAbsOrNull(string? s)
+    public decimal? ParseSignedOrNull(string? s)
     {
         if (string.IsNullOrWhiteSpace(s)) return null;
-        if (decimal.TryParse(s.Replace(",", ""), out var v)) return Math.Abs(v);
+        if (decimal.TryParse(s.Replace(",", ""), out var v)) return v;
         throw new FormatException($"Amount '{s}' is not a valid number.");
+    }
+
+    public decimal? ParseAbsOrNull(string? s)
+    {
+        var value = ParseSignedOrNull(s);
+        return value.HasValue ? Math.Abs(value.Value) : null;
     }
 }

--- a/src/CsvToOfx.Parsers/CsvToOfx.Parsers.csproj
+++ b/src/CsvToOfx.Parsers/CsvToOfx.Parsers.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14</LangVersion>
   </PropertyGroup>
 

--- a/src/CsvToOfx.Parsers/Providers/Fidelity/FidelityParser.cs
+++ b/src/CsvToOfx.Parsers/Providers/Fidelity/FidelityParser.cs
@@ -35,6 +35,9 @@ public sealed class FidelityParser : IStatementParser
             var nonEmpty = row.Values.Count(v => !string.IsNullOrWhiteSpace(v));
             if (nonEmpty <= 1) continue;
 
+            if (ShouldSkipSyntheticSweepReinvestment(row, columnsByField))
+                continue;
+
             // date filter
             var dt = ctx.DateParser.ParseOrNull(Get(row, columnsByField, CanonicalField.TradeDate));
             if (ctx.StartDateFilter.HasValue && dt.HasValue && dt.Value < ctx.StartDateFilter.Value) continue;
@@ -65,7 +68,7 @@ public sealed class FidelityParser : IStatementParser
 
             var units = TryParseDecimal(Get(row, columnsByField, CanonicalField.Quantity));
             var unitPrice = TryParseDecimal(Get(row, columnsByField, CanonicalField.Price));
-            var amount = ctx.AmountParser.ParseAbsOrNull(Get(row, columnsByField, CanonicalField.Amount)) ?? 0m;
+            var amount = ParseAmount(ctx, action, row, columnsByField);
             var memo = BuildMemo(action, row, columnsByField);
             var fees = TryParseDecimal(Get(row, columnsByField, CanonicalField.Fees));
             var currency = (Get(row, columnsByField, CanonicalField.Currency) ?? ctx.CurrencyDefault).Trim();
@@ -112,6 +115,40 @@ public sealed class FidelityParser : IStatementParser
 
     private static decimal? TryParseDecimal(string? s)
         => decimal.TryParse((s ?? "").Replace(",", ""), out var v) ? v : null;
+
+    private static decimal ParseAmount(
+        ParserContext ctx,
+        CanonicalAction action,
+        IDictionary<string, string?> row,
+        IReadOnlyDictionary<CanonicalField, string> columnsByField)
+    {
+        var rawAmount = Get(row, columnsByField, CanonicalField.Amount);
+        var amount = action == CanonicalAction.CashTransfer
+            ? ctx.AmountParser.ParseSignedOrNull(rawAmount)
+            : ctx.AmountParser.ParseAbsOrNull(rawAmount);
+
+        return amount ?? 0m;
+    }
+
+    private static bool ShouldSkipSyntheticSweepReinvestment(
+        IDictionary<string, string?> row,
+        IReadOnlyDictionary<CanonicalField, string> columnsByField)
+    {
+        var action = (Get(row, columnsByField, CanonicalField.Action) ?? "").Trim();
+        if (!action.Contains("reinvestment", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var symbol = (Get(row, columnsByField, CanonicalField.Symbol) ?? "").Trim();
+        if (!FidelityCorePositionSymbols.Contains(symbol))
+            return false;
+
+        var type = (Get(row, columnsByField, CanonicalField.Type) ?? "").Trim();
+        var description = (Get(row, columnsByField, CanonicalField.Description) ?? "").Trim();
+
+        return type.Contains("cash", StringComparison.OrdinalIgnoreCase)
+            || description.Contains("money market", StringComparison.OrdinalIgnoreCase)
+            || description.Contains("core", StringComparison.OrdinalIgnoreCase);
+    }
 
     private static string? BuildMemo(
         CanonicalAction action,

--- a/src/CsvToOfx.Writers.Ofx/CsvToOfx.Writers.Ofx.csproj
+++ b/src/CsvToOfx.Writers.Ofx/CsvToOfx.Writers.Ofx.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14</LangVersion>
   </PropertyGroup>
 

--- a/src/CsvToOfx.Writers.Qif/CsvToOfx.Writers.Qif.csproj
+++ b/src/CsvToOfx.Writers.Qif/CsvToOfx.Writers.Qif.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14</LangVersion>
   </PropertyGroup>
 

--- a/tests/CsvToOfx.Core.Tests/CsvToOfx.Core.Tests.csproj
+++ b/tests/CsvToOfx.Core.Tests/CsvToOfx.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/CsvToOfx.Core.Tests/ServicesTest.cs
+++ b/tests/CsvToOfx.Core.Tests/ServicesTest.cs
@@ -35,6 +35,15 @@ public class AmountParserTests
         Action act = () => _parser.ParseAbsOrNull("invalid");
         act.Should().Throw<FormatException>();
     }
+
+    [Theory]
+    [InlineData("1,234.56", 1234.56)]
+    [InlineData("-78.90", -78.90)]
+    [InlineData("100", 100.0)]
+    public void ParseSignedOrNull_PreservesSign_ForValidStrings(string input, decimal expected)
+    {
+        _parser.ParseSignedOrNull(input).Should().Be(expected);
+    }
 }
 
 public class DateParserTests

--- a/tests/CsvToOfx.Parsers.Tests/CsvToOfx.Parsers.Tests.csproj
+++ b/tests/CsvToOfx.Parsers.Tests/CsvToOfx.Parsers.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/CsvToOfx.Parsers.Tests/UnitTest1.cs
+++ b/tests/CsvToOfx.Parsers.Tests/UnitTest1.cs
@@ -115,4 +115,97 @@ Run Date,Action,Symbol,Description,Type,Price,Quantity,Commission,Fees,Amount
         result.Transactions[0].Action.Should().Be(CanonicalAction.SellStock);
         result.Transactions[0].Currency.Should().Be("USD");
     }
+
+    [Fact]
+    public void Parse_SkipsSyntheticCorePositionReinvestment_ForSpaxx()
+    {
+        const string csv = """
+Run Date,Action,Symbol,Description,Type,Exchange Quantity,Exchange Currency,Currency,Price,Quantity,Exchange Rate,Commission,Fees,Accrued Interest,Amount,Cash Balance,Settlement Date
+4/1/26,Dividend Received,SPAXX,FIDELITY GOVERNMENT MONEY MARKET (SPAXX) (Cash),Cash,,,USD,1.00,4.25,,0,0,0,4.25,1004.25,4/1/26
+4/1/26,Reinvestment,SPAXX,FIDELITY GOVERNMENT MONEY MARKET (SPAXX) (Cash),Cash,,,USD,1.00,4.25,,0,0,0,4.25,1004.25,4/1/26
+""";
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
+
+        var parser = new FidelityParser();
+        var ctx = new ParserContext
+        {
+            AccountId = "acct-spaxx",
+            Institution = "fidelity",
+            CurrencyDefault = "USD",
+            DateParser = new DateParser(),
+            AmountParser = new AmountParser(),
+            FitIdGenerator = new FitIdGenerator(),
+            SubacctResolver = new SubacctResolver(),
+            SecurityResolver = new SecurityResolver(preferCusip: false)
+        };
+
+        var result = parser.Parse(new RawStatement("fidelity", stream, ".csv"), ctx);
+
+        result.Transactions.Should().HaveCount(1);
+        result.Transactions[0].Security!.Ticker.Should().Be("SPAXX");
+        result.Transactions[0].Action.Should().Be(CanonicalAction.Income);
+        result.Transactions[0].Memo.Should().Be("Dividend Received - SPAXX");
+    }
+
+    [Fact]
+    public void Parse_KeepsNormalReinvestment_ForNonCorePositionSecurity()
+    {
+        const string csv = """
+Run Date,Action,Symbol,Description,Type,Exchange Quantity,Exchange Currency,Currency,Price,Quantity,Exchange Rate,Commission,Fees,Accrued Interest,Amount,Cash Balance,Settlement Date
+4/2/26,Reinvestment,VOO,Vanguard 500 Index Fund,Mutual Fund,,,USD,510.25,0.01,,0,0,0,5.10,1009.35,4/2/26
+""";
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
+
+        var parser = new FidelityParser();
+        var ctx = new ParserContext
+        {
+            AccountId = "acct-voo",
+            Institution = "fidelity",
+            CurrencyDefault = "USD",
+            DateParser = new DateParser(),
+            AmountParser = new AmountParser(),
+            FitIdGenerator = new FitIdGenerator(),
+            SubacctResolver = new SubacctResolver(),
+            SecurityResolver = new SecurityResolver(preferCusip: false)
+        };
+
+        var result = parser.Parse(new RawStatement("fidelity", stream, ".csv"), ctx);
+
+        result.Transactions.Should().HaveCount(1);
+        result.Transactions[0].Security!.Id.Should().Be("VOO");
+        result.Transactions[0].Action.Should().Be(CanonicalAction.BuyStock);
+    }
+
+    [Fact]
+    public void Parse_PreservesNegativeAmount_ForOutgoingCashTransfer()
+    {
+        const string csv = """
+Run Date,Action,Symbol,Description,Type,Exchange Quantity,Exchange Currency,Currency,Price,Quantity,Exchange Rate,Commission,Fees,Accrued Interest,Amount,Cash Balance,Settlement Date
+4/3/26,Transferred To VS Z24-467676 Redemption,,TRANSFERRED TO VS Z24-467676 REDEMPTION (Cash),Cash,,,USD,0,0,,0,0,0,-50.00,959.35,4/3/26
+""";
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(csv));
+
+        var parser = new FidelityParser();
+        var ctx = new ParserContext
+        {
+            AccountId = "acct-transfer-out",
+            Institution = "fidelity",
+            CurrencyDefault = "USD",
+            DateParser = new DateParser(),
+            AmountParser = new AmountParser(),
+            FitIdGenerator = new FitIdGenerator(),
+            SubacctResolver = new SubacctResolver(),
+            SecurityResolver = new SecurityResolver(preferCusip: false)
+        };
+
+        var result = parser.Parse(new RawStatement("fidelity", stream, ".csv"), ctx);
+
+        result.Transactions.Should().HaveCount(1);
+        result.Transactions[0].Action.Should().Be(CanonicalAction.CashTransfer);
+        result.Transactions[0].Amount.Should().Be(-50.00m);
+        result.Transactions[0].Memo.Should().Be("Transferred To VS Z24-467676 Redemption");
+    }
 }

--- a/tests/CsvToOfx.Writers.Tests/CsvToOfx.Writers.Tests.csproj
+++ b/tests/CsvToOfx.Writers.Tests/CsvToOfx.Writers.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Upgraded to .net 10
Fix issue with SPAXX - We don't buy SPAXX once we get the dividend
Fix issue with Transfer Amount. Instead of showing -50 for e.g., it was showing +50
